### PR TITLE
Update to Node.js 16 and ``actions/checkout@v3`` action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
   test:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./
         with:
           certificate: '${{ secrets.CS_CERT_BASE64 }}'

--- a/action.yml
+++ b/action.yml
@@ -29,5 +29,5 @@ inputs:
     default: 'http://timestamp.verisign.com/scripts/timstamp.dll'
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
-name: 'Signtool Code Sign'
+name: 'Signtool Code Sign (Reloaded)'
 description: 'Sign files with with a pfx certificate using signtool'
-author: 'Gabriel Acosta'
+author: 'Gabriel Acosta/Minionguyjpro'
 branding:
   icon: 'code'
   color: 'gray-dark'


### PR DESCRIPTION
Node.js 12 is getting deprecated for GitHub Actions. Upgrade to Node.js 16 to resolve this issue.